### PR TITLE
Fixed two bugs encountered in class

### DIFF
--- a/examples/OOCSI_multichannel_receiver/OOCSI_multichannel_receiver.ino
+++ b/examples/OOCSI_multichannel_receiver/OOCSI_multichannel_receiver.ino
@@ -72,7 +72,7 @@ void processOOCSI() {
     Serial.print("' at ");
     Serial.print(oocsi.getTimeStamp());
     Serial.println();
-  } else if (oocsi.getRecipient() == OOCSIName) {
+  } else if (oocsi.getRecipient() == oocsi.getName()) {
     Serial.print("A direct message for just me from sender '");
     Serial.print(oocsi.getSender());
     Serial.print("' at ");

--- a/src/DFDataset.cpp
+++ b/src/DFDataset.cpp
@@ -120,7 +120,7 @@ bool DFDataset::logItem() {
 
   #ifdef ESP8266
   http.begin(wifi, address/*, root_ca_df*/);
-  https.setAuthorization(root_ca_df);
+  http.setAuthorization(root_ca_df);
   #else
   http.begin(address);
   #endif
@@ -184,7 +184,7 @@ bool DFDataset::addItem() {
 
   #ifdef ESP8266
   http.begin(wifi, address/*, root_ca_df*/);
-  https.setAuthorization(root_ca_df);
+  http.setAuthorization(root_ca_df);
   #else
   http.begin(address);
   #endif
@@ -249,7 +249,7 @@ bool DFDataset::updateItem() {
 
   #ifdef ESP8266
   http.begin(wifi, address/*, root_ca_df*/);
-  https.setAuthorization(root_ca_df);
+  http.setAuthorization(root_ca_df);
   #else
   http.begin(address);
   #endif
@@ -306,7 +306,7 @@ bool DFDataset::deleteItem() {
 
   #ifdef ESP8266
   http.begin(wifi, address/*, root_ca_df*/);
-  https.setAuthorization(root_ca_df);
+  http.setAuthorization(root_ca_df);
   #else
   http.begin(address);
   #endif
@@ -374,7 +374,7 @@ bool DFDataset::getItem() {
 
   #ifdef ESP8266
   http.begin(wifi, address/*, root_ca_df*/);
-  https.setAuthorization(root_ca_df);
+  http.setAuthorization(root_ca_df);
   #else
   http.begin(address);
   #endif

--- a/src/OOCSI.cpp
+++ b/src/OOCSI.cpp
@@ -242,11 +242,15 @@ bool OOCSI::internalConnect() {
     // continue with client-server handshake
     for(int i = 0; i < strlen(OOCSIName); i++) {
       if(OOCSIName[i] == '#') {
-        client.print(random(0, 10));
+        int rand=random(0, 10);
+        client.print(rand);
+        name_buffer[i] = '0'+rand;
       } else {
         client.print(OOCSIName[i]);
+        name_buffer[i] = OOCSIName[i];
       }
     }
+    name_buffer[strlen(OOCSIName)] = '\0'; //terminate with null character
     
     client.println(F("(JSON)"));
 
@@ -715,7 +719,8 @@ bool OOCSI::containsClient(const char* clientName) {
 
 // return the client name
 String OOCSI::getName() {
-  return OOCSIName;
+  const char* currentOOCSIName = (const char*)name_buffer;
+  return currentOOCSIName;
 }
 
 // return current version

--- a/src/OOCSI.h
+++ b/src/OOCSI.h
@@ -117,6 +117,7 @@ class OOCSI {
 
     // OOCSI
     const char* OOCSIName;
+    char name_buffer[100];
     const char* host;
     const uint16_t port = 4444;
     WiFiClient client;


### PR DESCRIPTION
Here is a fix for the following bugs:
1)  OOCSI ESP did not compile for ESP8266
- this was caused by typos

2) `oocsi.getName()` did not return the real name with random numbers
- The library replaced `#`s in the name when connecting, but this random name was not available in `oocsi.getName()`
I added a buffer that stores the real name that the connection is established with and return this under getName. This also includes a fix for the related multichannel_receiver example code allowing to check if a message was sent to the device directly.